### PR TITLE
feat: ghost cursor

### DIFF
--- a/src/content/main.ts
+++ b/src/content/main.ts
@@ -3,13 +3,16 @@ import {
   ExtensionMessage,
   ExtensionMessageTypeEnum,
   SessionRecord,
+  SessionRoleEnum,
 } from '@/shared/types';
 import { EventCapture, EventReplay } from './mirror';
 import { RoleBadge } from './role-badge';
+import { VirtualCursor } from './virtual-cursor';
 import { logger } from '@/shared/util';
 
+const cursor = new VirtualCursor();
 const capture = new EventCapture();
-const replay = new EventReplay();
+const replay = new EventReplay(cursor);
 const badge = new RoleBadge();
 
 chrome.runtime.onMessage.addListener((message: ExtensionMessage) => {
@@ -17,6 +20,11 @@ chrome.runtime.onMessage.addListener((message: ExtensionMessage) => {
     case ExtensionMessageTypeEnum.SetRole: {
       capture.setRole(message.role);
       badge.update(message.role);
+      if (message.role === SessionRoleEnum.Target) {
+        cursor.show();
+      } else {
+        cursor.hide();
+      }
       logger.log(`Role set to: ${message.role}`);
       break;
     }

--- a/src/content/mirror.ts
+++ b/src/content/mirror.ts
@@ -4,6 +4,7 @@ import {
   DomEventTypeEnum,
   DomInputEventPayload,
   DomKeyboardEventPayload,
+  DomMousemoveEventPayload,
   DomScrollEventPayload,
   ExtensionMessage,
   ExtensionMessageTypeEnum,
@@ -12,6 +13,7 @@ import {
   SessionRoleEnum,
 } from '@/shared/types';
 import { getElementMeta, getSemanticSelector, logger } from '@/shared/util';
+import { VirtualCursor } from './virtual-cursor';
 
 // are not re-captured and forwarded in an infinite loop.
 let isReplaying = false;
@@ -47,6 +49,9 @@ class Record {
 
 export class EventCapture {
   private scrollTimer: ReturnType<typeof setTimeout> | null = null;
+  private rafPending = false;
+  private lastMouseXRatio = 0;
+  private lastMouseYRatio = 0;
   private role: SessionRole = SessionRoleEnum.Idle;
 
   constructor() {
@@ -196,10 +201,40 @@ export class EventCapture {
       },
       true,
     );
+
+    document.addEventListener(
+      'mousemove',
+      (e: MouseEvent) => {
+        if (!this.active()) return;
+        this.lastMouseXRatio = e.clientX / window.innerWidth;
+        this.lastMouseYRatio = e.clientY / window.innerHeight;
+
+        if (this.rafPending) return;
+        this.rafPending = true;
+        requestAnimationFrame(() => {
+          this.rafPending = false;
+          if (!this.active()) return;
+          const content: DomMousemoveEventPayload = {
+            xRatio: this.lastMouseXRatio,
+            yRatio: this.lastMouseYRatio,
+          };
+          sendDomEvent({
+            type: DomEventTypeEnum.Mousemove,
+            selector: 'window',
+            content,
+          });
+        });
+      },
+      true,
+    );
   }
 }
 
 export class EventReplay extends Record {
+  constructor(private readonly cursor: VirtualCursor) {
+    super();
+  }
+
   replay(payload: DomEventPayload): void {
     isReplaying = true;
 
@@ -226,6 +261,15 @@ export class EventReplay extends Record {
         return;
       }
 
+      if (type === DomEventTypeEnum.Mousemove) {
+        const { xRatio, yRatio } = payload.content as DomMousemoveEventPayload;
+        this.cursor.moveTo(
+          xRatio * window.innerWidth,
+          yRatio * window.innerHeight,
+        );
+        return;
+      }
+
       const element = this.resolveElement(selector) as HTMLElement | null;
 
       if (!element) {
@@ -238,6 +282,8 @@ export class EventReplay extends Record {
           const { offsetXRatio, offsetYRatio } =
             payload.content as DomClickEventPayload;
           const rect = element.getBoundingClientRect();
+          const clickX = rect.left + offsetXRatio * rect.width;
+          const clickY = rect.top + offsetYRatio * rect.height;
           const content: DomClickEventPayload = {
             offsetXRatio,
             offsetYRatio,
@@ -249,12 +295,14 @@ export class EventReplay extends Record {
             content,
           });
 
+          this.cursor.animateClick(clickX, clickY);
+
           element.dispatchEvent(
             new MouseEvent('click', {
               bubbles: true,
               cancelable: true,
-              clientX: rect.left + offsetXRatio * rect.width,
-              clientY: rect.top + offsetYRatio * rect.height,
+              clientX: clickX,
+              clientY: clickY,
             }),
           );
           break;

--- a/src/content/virtual-cursor.ts
+++ b/src/content/virtual-cursor.ts
@@ -1,0 +1,133 @@
+import { APP_NAME } from '@/shared/consts';
+
+export class VirtualCursor {
+  private readonly host: HTMLDivElement;
+  private readonly cursorEl: HTMLElement;
+  private readonly rippleEl: HTMLElement;
+
+  constructor() {
+    const { host, cursorEl, rippleEl } = this.mount();
+    this.host = host;
+    this.cursorEl = cursorEl;
+    this.rippleEl = rippleEl;
+    this.hide();
+  }
+
+  moveTo(x: number, y: number): void {
+    this.cursorEl.style.transform = `translate(${String(Math.round(x))}px, ${String(Math.round(y))}px)`;
+  }
+
+  animateClick(x: number, y: number): void {
+    this.moveTo(x, y);
+
+    const r = this.rippleEl;
+    r.style.setProperty('--rx', `${String(Math.round(x - 16))}px`);
+    r.style.setProperty('--ry', `${String(Math.round(y - 16))}px`);
+    r.classList.remove('active');
+    void r.offsetWidth;
+    r.classList.add('active');
+  }
+
+  show(): void {
+    this.host.style.display = 'block';
+  }
+
+  hide(): void {
+    this.host.style.display = 'none';
+  }
+
+  private mount(): {
+    host: HTMLDivElement;
+    cursorEl: HTMLElement;
+    rippleEl: HTMLElement;
+  } {
+    const host = document.createElement('div');
+    host.id = `${APP_NAME}-cursor-host`;
+    Object.assign(host.style, {
+      all: 'initial',
+      position: 'fixed',
+      top: '0',
+      left: '0',
+      width: '0',
+      height: '0',
+      pointerEvents: 'none',
+      zIndex: '2147483647',
+      overflow: 'visible',
+    });
+
+    const shadow = host.attachShadow({ mode: 'open' });
+
+    const style = document.createElement('style');
+    style.textContent = `
+      .mt-cursor {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 18px;
+        height: 21px;
+        pointer-events: none;
+        transform: translate(0, 0);
+        transition: transform 50ms linear;
+        will-change: transform;
+        filter:
+          drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35))
+          drop-shadow(0 0px 4px rgba(100, 255, 218, 0.2));
+      }
+
+      .mt-ripple {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        border: 2px solid rgba(100, 255, 218, 0.7);
+        box-shadow: 0 0 0 0 rgba(100, 255, 218, 0.25);
+        background: rgba(100, 255, 218, 0.07);
+        pointer-events: none;
+        opacity: 0;
+        transform: translate(0, 0) scale(0);
+      }
+
+      .mt-ripple.active {
+        animation: mt-ripple-anim 480ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+      }
+
+      @keyframes mt-ripple-anim {
+        0%   { transform: translate(var(--rx), var(--ry)) scale(0.15); opacity: 1; }
+        60%  { opacity: 0.7; }
+        100% { transform: translate(var(--rx), var(--ry)) scale(1.9);  opacity: 0; }
+      }
+    `;
+
+    const cursorEl = document.createElement('div');
+    cursorEl.className = 'mt-cursor';
+    cursorEl.innerHTML = `
+      <svg width="18" height="21" viewBox="0 0 22 26"
+           fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path
+          d="M3.5 2L3.5 21.5L8 17L11.5 24.5L14.5 23L11 15.5L17.5 15.5L3.5 2Z"
+          fill="white"
+          stroke="#64ffda"
+          stroke-width="1.5"
+          stroke-linejoin="round"
+          stroke-linecap="round"
+        />
+      </svg>
+    `.trim();
+
+    const rippleEl = document.createElement('div');
+    rippleEl.className = 'mt-ripple';
+    rippleEl.addEventListener('animationend', () => {
+      rippleEl.classList.remove('active');
+    });
+
+    shadow.appendChild(style);
+    shadow.appendChild(cursorEl);
+    shadow.appendChild(rippleEl);
+
+    document.documentElement.appendChild(host);
+
+    return { host, cursorEl, rippleEl };
+  }
+}

--- a/src/shared/types/dom-events.ts
+++ b/src/shared/types/dom-events.ts
@@ -2,6 +2,11 @@ export interface DomInputEventPayload {
   value: string;
 }
 
+export interface DomMousemoveEventPayload {
+  xRatio: number;
+  yRatio: number;
+}
+
 export interface DomScrollEventPayload {
   scrollX: number;
   scrollY: number;
@@ -25,7 +30,8 @@ export type DomEventContent =
   | DomInputEventPayload
   | DomScrollEventPayload
   | DomKeyboardEventPayload
-  | DomClickEventPayload;
+  | DomClickEventPayload
+  | DomMousemoveEventPayload;
 
 export const DomEventTypeEnum = {
   Click: 'click',
@@ -34,6 +40,7 @@ export const DomEventTypeEnum = {
   Change: 'change',
   Keydown: 'keydown',
   Keyup: 'keyup',
+  Mousemove: 'mousemove',
 } as const;
 
 export type DomEventType =

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -13,6 +13,7 @@ export type {
   DomScrollEventPayload,
   DomKeyboardEventPayload,
   DomClickEventPayload,
+  DomMousemoveEventPayload,
   DomEventContent,
 } from './dom-events';
 export { DomEventTypeEnum } from './dom-events';

--- a/src/shared/util/tab.ts
+++ b/src/shared/util/tab.ts
@@ -57,7 +57,6 @@ export async function sendRoleToTab(
 
 export async function injectContentScript(tabId: number): Promise<void> {
   try {
-    // TODO: check files on built version
     await chrome.scripting.executeScript({
       target: { tabId },
       files: ['src/content/main.ts'],


### PR DESCRIPTION
### Description

Adds a ghost cursor to the Target tab that mirrors the Source tab's mouse position in real time. Includes a click ripple animation at the exact coordinates where each click lands.

Implementation: a shadow-DOM isolated VirtualCursor injected into the target content script, fed by RAF-throttled `mousemove` events using viewport-relative ratios.

### Additional Details

<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/933dbbd2-f751-4610-8147-01b5f4b6029f" />

### Links

- [X] Fixes: #2 
- [ ] Related to: #
